### PR TITLE
Move codeblock.js into gh-pages branch and link directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ console.log("and see what events are thrown");</div>
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="javascripts/ace.js"></script>
-    <script src="https://raw.github.com/Filepicker/codeblock.js/master/codeblock.js" type="text/javascript"></script>
+    <script src="javascripts/codeblock.js" type="text/javascript"></script>
     <script src="javascripts/main.js"></script>
   </body>
 </html>

--- a/javascripts/codeblock.js
+++ b/javascripts/codeblock.js
@@ -1,0 +1,290 @@
+// the semi-colon before function invocation is a safety net against concatenated
+// scripts and/or other plugins which may not be closed properly.
+;(function ( $, window, document, undefined ) {
+    // undefined is used here as the undefined global variable in ECMAScript 3 is
+    // mutable (ie. it can be changed by someone else). undefined isn't really being
+    // passed in so we can ensure the value of it is truly undefined. In ES5, undefined
+    // can no longer be modified.
+
+    // window and document are passed through as local variable rather than global
+    // as this (slightly) quickens the resolution process and can be more efficiently
+    // minified (especially when both are regularly referenced in your plugin).
+
+    // Create the defaults once
+    var pluginName = "codeblock",
+        defaults = {
+          editable: true,
+          consoleText: "Output from the example appears here",
+		  consoleClass: "codeblock-console-text",
+          runButtonText: "run",
+          runButtonClass: "codeblock-console-run",
+          console: true,
+          resetable: true,
+          runnable: true,
+          editorTheme: "ace/theme/dawn",
+          lineNumbers: true
+        };
+
+    // The actual plugin constructor
+    function CodeBlock( element, options ) {
+        this.element = element;
+        this.original = $(this.element);
+		this.enabled = true;
+
+        // jQuery has an extend method which merges the contents of two or
+        // more objects, storing the result in the first object. The first object
+        // is generally empty as we don't want to alter the default options for
+        // future instances of the plugin
+        this.options = $.extend( {}, defaults, options );
+
+        this._defaults = defaults;
+        this._name = pluginName;
+        this._exports = {
+            "run": this.run,
+            "reset": this.reset,
+            "destroy": this.destroy,
+            "editor": this.getEditor,
+            "text": this.getSetText,
+            "runnable": this.getSetRunnable,
+            "editable": this.getSetEditable
+        };
+
+        this.init();
+    }
+
+    CodeBlock.prototype = {
+        init: function() {
+          this.setUpDom();
+          this.setUpEditor();
+          if (this.options.console) {
+            this.createConsole();
+          }
+          if (this.options.resetable) {
+            this.createResetButton();
+          }
+		  this.base.data("plugin_" + pluginName, this);
+        },
+
+        setUpDom: function() {
+            //the ACE editor directly manipulates the classes, etc. of the
+            //element it latches on to, so we set up an encapsulating DOM structure
+            this.el = $('<div></div>').addClass("codeblock-container");
+            var inner = $('<div></div>').addClass("codeblock-editor-wrapper");
+
+			this.base = this.original.clone();
+
+            //A set width & height keeps the editor the right size.
+            //TODO: make this configurable
+            var width = this.original.width();
+            this.el.width(width);
+            inner.height(this.original.height()*1.1);
+
+            //Strip whitespace to make writing html easier
+            this.base.html($.trim(this.base.html()));
+            this.base.addClass("codeblock-editor");
+
+			this.originalText = this.base.text();
+
+            this.el.insertBefore(this.original);
+            this.el.append(inner);
+            inner.append(this.base);
+			this.original.remove();
+        },
+
+        setUpEditor: function() {
+            //Set up ace editor - requires an ID to latch on to
+            if (!this.base.attr("id")) {
+                this.base.attr("id", "codeblock-editor-"+(+new Date));
+            }
+
+            this.editor = ace.edit(this.base.attr("id"));
+            this.editor.setTheme(this.options.editorTheme);
+            this.editor.getSession().setUseWorker(false);
+            this.editor.getSession().setMode("ace/mode/javascript");
+            this.editor.setShowFoldWidgets(false);
+            //override their fancy ctrl-f, ctrl-r: http://stackoverflow.com/questions/13677898/how-to-disable-ace-editors-find-dialog
+            this.editor.commands.addCommands([{
+                    name: "unfind",
+                    bindKey: { win: "Ctrl-F", mac: "Command-F" },
+                    exec: function(editor, line) { return false; },
+                    readOnly: true
+            }, {
+                    name: "unreplace",
+                    bindKey: { win: "Ctrl-R", mac: "Command-R" },
+                    exec: function(editor, line) { return false; },
+                    readOnly: true
+            }]);
+
+            this.editor.setReadOnly(!this.options.editable);
+			this.editor.renderer.setShowGutter(this.options.lineNumbers); 
+        },
+
+        createConsole: function() {
+            var console_wrapper = $('<div></div>').addClass("codeblock-console");
+            this.console  = $("<span></span>").addClass("codeblock-console-text");
+            console_wrapper.append(this.console);
+            this.console.text(this.options.consoleText);
+            this.console.addClass("placeholder");
+            this.console.width(this.el.width() - 70);
+
+			if (this.options.runnable) {
+				this.runButton = $("<span></span>").addClass("codeblock-console-run");
+				this.runButton.text(this.options.runButtonText);
+
+				var cur = this;
+				this.runButton.click(function() {
+				  if (cur.enabled) {
+					  cur.run();
+				  }
+				});
+				console_wrapper.append(this.runButton);
+			}
+
+            this.el.append(console_wrapper);
+        },
+
+        createResetButton: function() {
+            var reset_button = $("<i></i>").addClass("codeblock-reset").attr("title", "Reset");
+
+            var cur = this;
+            reset_button.click(function() {
+              cur.reset();
+              return false;
+            });
+            this.base.after(reset_button);
+        },
+
+		destroy: function() {
+			this.editor.destroy();
+			this.editor = undefined;
+			this.options = undefined;
+			this.originalText = undefined;
+			this.console = undefined;
+			this.runButton = undefined;
+
+			this.original.insertBefore(this.el);
+			$.removeData(this.element, "plugin_" + pluginName);
+			this.base.removeData("plugin_" + pluginName);
+
+			this.base.remove();
+			this.base = undefined;
+			this.el.remove();
+			this.el = undefined;
+		},
+
+        run: function() {
+		    this.base.add(this.original).trigger("codeblock.run");
+
+            var val = this.editor.getValue();
+            //clear text
+            this.console.text('');
+            this.console.removeClass("placeholder");
+            var cur = this;
+            //closure to overload console
+            (function(){
+                var c = {};
+                c.log = function() {
+                    var text = $.makeArray(arguments).join(" ");
+                    var currText = cur.console.html();
+                    currText += text + "<br/>";
+                    cur.console.html(currText);
+					cur.base.add(cur.original).trigger("codeblock.console", [text]);
+                };
+                try {
+                    //To catch returns & exceptions
+                    //NOTE - this must be minified "by hand" to make sure that
+                    //the variable named "console" is preserved
+                    //Depending on your minifier, you may be able to set javascript
+                    //comment flags to tell the minifier not to compile this
+                    (function(console){eval(val);})(c);
+                } catch (err) {
+                    c.log("Error:", err);
+                }
+            })();
+
+		    return this;
+        },
+
+        reset: function() {
+          this.base.add(this.original).trigger("codeblock.reset");
+
+          this.editor.setValue(this.originalText);
+          this.editor.clearSelection();
+          this.editor.navigateFileStart();
+          this.console.text(this.options.consoleText);
+          this.console.addClass('placeholder');
+
+		  return this;
+        },
+
+		getSetText: function(newText) {
+		  if (newText !== undefined) {
+			  this.editor.setValue(newText);
+			  return this;
+		  } else {
+			  return this.editor.getValue();
+		  }
+		},
+
+		getEditor: function(){
+		  return this.editor;
+		},
+
+		getSetEditable: function(param){
+		  if (param !== undefined) {
+			  this.editor.setReadOnly(!param);
+			  return this;
+		  } else {
+			  return !this.editor.getReadOnly();
+		  }
+		},
+
+		getSetRunnable: function(param){
+		  if (param !== undefined) {
+			  this.enabled = param;
+			  this.runButton.toggleClass("disabled", !param);
+			  return this;
+		  } else {
+		  	  return this.options.runnable && this.enabled;
+		  }
+		}
+    };
+
+    // A really lightweight plugin wrapper around the constructor,
+    // preventing against multiple instantiations and allowing for
+    // jquery-ui like method calls
+    $.fn[pluginName] = function () {
+		if (arguments.length === 0 || (arguments.length == 1 && typeof arguments[0] === "object")) {
+			//constructor
+			var options = arguments[0];
+            return this.each(function(){
+                var codeblock = $.data(this, "plugin_" + pluginName);
+				if (!codeblock) {
+                    codeblock = new CodeBlock( this, options );
+					$.data(this, "plugin_" + pluginName, codeblock);
+				}
+			});
+		} else {
+			//action (i.e. $(".blah").codeblock('run');
+			var action = arguments[0];
+			var params = Array.prototype.slice.call(arguments, 1);
+            var ret = this.map(function(){
+				var codeblock = $.data(this, "plugin_" + pluginName);
+				if (codeblock) {
+					var method = codeblock._exports[action];
+					if (!method) { throw "Codeblock has no method "+action;}
+					return method.apply(codeblock, params);
+				}
+			}).get();
+
+            //return "this" for everything but the getters
+            if (action === "editor" || (params.length ===0 && (action == "runnable" || action == "editable"))) {
+                return ret.length >= 1 ? ret[0] : undefined;
+            } else if (params.length === 0 && action == "text") {
+                return ret.join();
+            } else {
+                return this;
+            }
+		}
+    };
+})( jQuery, window, document );


### PR DESCRIPTION
Since Github changed their mime-type of raw files linked, in Chrome at least you cannot execute the JavaScript files using raw Github links. This moves the main code in codeblock.js into the gh-pages branch and links to it directly in the index.html page.

closes #2
